### PR TITLE
Update FormalFrontier templates

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -18,52 +18,35 @@ Push sorries earlier. State the theorem first, sorry the proof, then fill in. Do
 ### Spec-Driven Development
 Use `sorry` placeholders with comments explaining what's needed. Never use `True` as a placeholder for propositions — it hides the actual requirements and will need a full refactor to fix.
 
+### Definitions Must Be Constructed
+**Never sorry the body of a `def`, `noncomputable def`, `instance`, or `abbrev`.** A sorry'd definition means the mathematical object does not exist — any theorem referencing it is vacuous. Proof obligations *within* a definition (e.g., `where` clauses) may use sorry, but the data itself must be real. See Stage 3.1 in PLAN.md for details and examples.
+
 ### Discussion Blobs Are First-Class
 During structure analysis (Stage 1.5), unstructured text between numbered items must be identified and tracked just like theorems and definitions. These discussion paragraphs carry context that proofs depend on. Every byte of the book must belong to exactly one blob.
 
 ### Conservative Dependencies
-Store only **direct** dependencies. The conservative default is a linear chain: each item depends only on its immediate predecessor. Never store transitive closure — that creates an O(N²) file with no useful information. We trim to actual direct dependencies later (Stage 3.3) once proofs exist.
+Store only **direct** dependencies. The conservative default is a linear chain: each item depends only on its immediate predecessor. Never store transitive closure — that creates an O(N²) file with no useful information. We trim to actual direct dependencies later (Stage 3.4) once proofs exist.
 
 ## When Stuck
 
-- **3 failed proof attempts**: escalate the proof to Aristotle (see below), then if that also fails, document in a GitHub issue and move on
-- **3 failed attempts on a non-proof sub-task** (definitions, statement formalization): skip it, document in a GitHub issue, move on (Aristotle only handles proofs)
-- **Dependency blocked:** Post an issue with `- [ ] depends on #X` and add the `blocked` label
+### Read the book first (mandatory)
+
+**Before attempting any proof**, read the blob file for the item (`blobs/<Chapter>/<Item>.md`). The book contains the proof strategy — follow it. Do not invent your own proof approach from mathematical knowledge.
+
+If the book's proof says "by Lemma X.Y.Z" or "the result follows from [earlier result]":
+1. Find that earlier result in the project (search `blobs/` and the Lean files)
+2. Use it in your proof — even if it still has a `sorry`. A sorry'd dependency is not a blocker.
+
+**Never say "not in Mathlib" without first checking the book.** The book's proofs build on earlier results in the book. Those results are what you should be using — not searching Mathlib for advanced infrastructure like Schur functors or Schur-Weyl duality when the book uses an elementary lemma from the previous page.
+
+### Escalation ladder
+
+- **3 failed attempts on any sub-task** (proof, definition construction, statement formalization): document in a GitHub issue and move on
+- **Dependency blocked:** Post an issue with `- [ ] depends on #X` and add the `blocked` label — but only for *definition-level* blockers, never for proof-level sorries
 - **Definition seems wrong:** Post an issue describing the problem — don't silently work around bad definitions
-- **Missing Mathlib API:** Post an issue describing what's needed; another agent or human can add it
+- **Definition-level sorry found:** This is highest priority. The mathematical object must be constructed — see "Definitions Must Be Constructed" above. Create an issue and fix it before proving downstream theorems.
+- **Missing Mathlib API:** First check whether the missing result is an earlier item in the book. If it is, that's a dependency, not a missing Mathlib API. If genuinely missing from Mathlib, **prove it here** — that's the highest-priority work, not a reason to defer. This project exists to formalize what isn't in Mathlib.
 - **Ordering mistake in the plan:** Report it — request a replan rather than hacking around it
-
-## Aristotle Escalation
-
-Aristotle is an automated theorem prover. Escalate to it when Claude can't prove a theorem after 2-3 serious attempts.
-
-### When to use Aristotle
-
-- A proof is beyond Claude's ability after multiple attempts
-- Standard mathematical proofs (calculus, algebra, analysis) that follow well-known patterns
-- Batch proving: after Stage 3.1 scaffolding, submit all sorry'd theorems
-
-### When NOT to use Aristotle
-
-- Statement formalization (translating definitions/theorem statements from natural language) — Claude handles this
-- When the formalized statement might be wrong — fix the statement first
-- For discussion blobs or non-theorem items
-
-### Handoff protocol
-
-1. Create a temporary copy of the item's Lean file (preserving all imports, namespaces, notation). Keep exactly one `sorry` (the target proof); change all others to `admit`.
-2. Gather context files: sorry-free local Lean files from the import chain (skip Mathlib imports). If no local files are sorry-free yet, submit with no context files.
-3. Submit: `aristotle prove-from-file item_pending.lean --no-wait --no-auto-add-imports --context-files ...`
-4. Record the project ID in `progress/items.json` with status `sent_to_aristotle`
-5. Delete the temp file — never commit `admit`
-
-**Deduplication:** Before submitting, check that the item is not already in `sent_to_aristotle` status. Only one submission per item at a time.
-
-### After Aristotle returns
-
-- **Success:** Verify the proof compiles (`lake env lean`), copy into the item's Lean file, update status to `sorry_free` (if all sorries resolved) or `proof_formalized`
-- **False statement:** Mark `attention_needed`, post a GitHub issue with the counterexample — the formalized statement needs fixing
-- **Failure/timeout/version mismatch:** Mark `attention_needed`, move on
 
 ## PR Workflow
 
@@ -98,7 +81,6 @@ Never skip this step. Downstream agents are blocked on `main` until merged PRs l
 - **Per-turn handoff files:** `progress/YYYY-MM-DDTHH-MM-SSZ.md` (UTC timestamp)
 - Stage-level summary: `PROGRESS.md` (optional, human-facing)
 - Item-level: `progress/items.json`
-- Formalization status: tracked in `progress/items.json`
 - Do NOT modify `PLAN.md` — it is the reference plan
 - Blockers and discussion: GitHub issues
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/.lake
-.pod/
-sessions/
-worktrees/
+.lake/
+lake-packages/
+build/
+.DS_Store

--- a/PLAN.md
+++ b/PLAN.md
@@ -19,21 +19,15 @@ pdfseparate source/original.pdf pdf/raw-pages/%d.pdf
 
 ### Stage 1.2: Start Lean Build
 
-The `lean/` directory was created by `ff init` using `lake init <ProjectName> math`, where `<ProjectName>` is the repository name with the `FormalFrontier-` prefix stripped (e.g., `FormalFrontier-Rudin` → `Rudin`). Start downloading Mathlib now so it is ready by the time formalization begins.
+The Lean project was created at the repo root by `ff init` using `lake init <ProjectName> math`, where `<ProjectName>` is the repository name with the `FormalFrontier-` prefix stripped (e.g., `FormalFrontier-Rudin` → `Rudin`). Start downloading Mathlib now so it is ready by the time formalization begins.
 
 ```bash
-cd lean && lake build
+lake exe cache get &&  lake build
 ```
-
-This takes ~30 minutes the first time (Mathlib download and build). Start it in the background and proceed with the remaining Phase 1 stages. Having the Lean project available early allows agents to test Lean snippets while transcribing and analyzing structure.
-
-**Output:** `lean/.lake/` with compiled Mathlib artifacts.
-
-**Verify:** `cd lean && lake build` exits successfully.
 
 ### Stage 1.3: Frontmatter Detection
 
-This is a **lightweight pass**. Start by examining the first ~20 pages and the last ~10 pages of `pdf/raw-pages/` — that is usually sufficient. If a book has an unusually long preface, TOC, or index, look at a few more pages until the boundary is clear. You do not need to read the entire book.
+Start by examining the first ~20 pages and the last ~10 pages of `pdf/raw-pages/` — that is usually sufficient. If a book has an unusually long preface, TOC, or index, look at a few more pages until the boundary is clear. You do not need to read the entire book.
 
 Determine:
 - Where "page 1" of the book actually starts (after title page, copyright, table of contents, preface, etc.)
@@ -46,7 +40,7 @@ Copy pages into `pdf/pages/` with the appropriate names. (`pdf/raw-pages/` is th
 
 **All pages are included** — frontmatter, main content, and backmatter all get entries in `pdf/pages/`. Nothing is discarded.
 
-After copying, write `pdf/pages/mapping.json` recording the raw-page → logical-page correspondence. This is the authoritative record of the frontmatter boundary decision; subsequent stages that need to map between raw and logical page numbers must read this file rather than reverse-engineering it from filenames.
+After copying, write `pdf/pages/mapping.json` recording the raw-page → logical-page correspondence. 
 
 Format:
 ```json
@@ -129,6 +123,7 @@ Identify every piece of content in the book and assign it to a blob. The goal is
 
 **Formally numbered items:**
 - Theorems, lemmas, propositions, corollaries
+- Proofs of theorems, lemmas, and propositions
 - Definitions
 - Examples, exercises
 - Remarks, notes
@@ -224,37 +219,9 @@ Categorize each:
 
 **Output:** `dependencies/external.json` — a list of external dependencies, each with a description, the items that need it, and the category.
 
-### Stage 2.3: Blueprint Assembly
+### Stage 2.3: Research — Mathlib Coverage
 
-Combine `items.json`, `dependencies/internal.json`, and `dependencies/external.json` into a preliminary blueprint.
-
-This is a DAG of what needs to be formalized and in what order. Because the initial dependencies form a linear chain (each item depends only on its immediate predecessor), the initial DAG is a single path. That is fine — it will be refined in Stage 3.3.
-
-#### Blueprint tooling
-
-The blueprint uses a hybrid of two tools:
-
-- **leanblueprint** (https://github.com/PatrickMassot/leanblueprint): The rendering substrate. Produces an interactive HTML website with a dependency DAG and a PDF document. Uses LaTeX source with special macros (`\uses{}`, `\lean{}`, `\leanok`). This handles **all** blueprint nodes — both formal declarations and non-formal content (discussion blobs, introductions, external dependencies).
-- **LeanArchitect** (https://github.com/hanwenzhu/LeanArchitect, using https://github.com/kim-em/LeanArchitect/tree/blueprint-all until https://github.com/hanwenzhu/LeanArchitect/pull/8 is merged): Complements leanblueprint for Lean-backed nodes. Run externally with `extract_blueprint --all` against the project's compiled `.olean` files — no `require`, `import`, or attributes needed in the Lean source. Automatically infers dependencies between formal declarations and tracks formalization status via sorry detection. Provides JSON export for agent consumption.
-
-The split: leanblueprint owns the full DAG (formal + non-formal nodes). LeanArchitect automates the Lean-backed portion (theorems, definitions, lemmas), eliminating manual `\leanok` and `\uses{}` maintenance for those nodes. Non-formal nodes (discussion, introductions, external dependencies) use leanblueprint's LaTeX macros directly. The Lean source files are completely free of blueprint annotations.
-
-#### Steps
-
-1. Set up leanblueprint scaffolding in `blueprint/` (use `leanblueprint new` or copy from a template).
-2. Generate LaTeX blueprint nodes from `items.json` and dependency data. Each item becomes a LaTeX environment with `\label{}` and `\uses{}` annotations.
-3. Non-formalizable items (discussion, introduction, etc.) are included as LaTeX nodes for completeness — they appear in the DAG but don't need Lean declarations.
-4. Run `leanblueprint web` to generate the HTML dependency graph.
-
-The initial blueprint is purely LaTeX-based. LeanArchitect integration happens after Stage 3.1 when Lean scaffolding is compiled — run `extract_blueprint --all --json` against the `.olean` files to get the dependency graph and formalization status.
-
-**Output:** `blueprint/` directory with leanblueprint LaTeX source files.
-
-**Verify:** `leanblueprint web` succeeds and produces a valid dependency graph.
-
-### Stage 2.4: Research — Mathlib Coverage
-
-For each external dependency and each item, search Mathlib for relevant material.
+For each external dependency and each item, search Mathlib for relevant material. For large books, orchestrate this via issues (one per chapter) so that multiple agents can research in parallel.
 
 - Is this definition already in Mathlib? Under what name?
 - Is this theorem already proved? At what generality?
@@ -262,7 +229,7 @@ For each external dependency and each item, search Mathlib for relevant material
 
 **Output:** `research/mathlib-coverage.json` — mapping items and external deps to Mathlib declarations (with `#check` names).
 
-### Stage 2.5: Research — External Sources
+### Stage 2.4: Research — External Sources
 
 For items and dependencies not covered by Mathlib:
 
@@ -272,7 +239,7 @@ For items and dependencies not covered by Mathlib:
 
 **Output:** `research/external-sources.json`
 
-### Stage 2.6: Readiness Report
+### Stage 2.5: Readiness Report
 
 Prepare a human-readable report summarizing:
 
@@ -283,9 +250,9 @@ Prepare a human-readable report summarizing:
 
 **Output:** `READINESS.md`
 
-**Note:** This report is informational — do not pause for human review. Write the report and immediately continue to Stage 2.7.
+**Note:** This report is informational — do not pause for human review. Write the report and immediately continue to Stage 2.6.
 
-### Stage 2.7: Reference Attachment
+### Stage 2.6: Reference Attachment
 
 For each blob that has external dependencies or Mathlib matches, create a companion reference file.
 
@@ -297,39 +264,7 @@ These files are read by formalization agents when they work on the corresponding
 
 ## Phase 3: Formalization
 
-### Stage 3.1: Lean Scaffolding
-
-The `lean/` project was created by `ff init` in Stage 1.2 and Mathlib was built then. Create `.lean` files for each formalizable item (theorems, definitions, lemmas — not discussion blobs).
-
-Set up the import chain:
-- Root file: `lean/{Title}.lean` importing all chapter files
-- Chapter files: `lean/{Title}/Chapter1.lean` importing all items in the chapter
-- Item files: `lean/{Title}/Chapter1/Theorem1_1.lean` with a sorry'd statement
-
-Each item file should contain:
-- A sorry'd `theorem` or `def` statement based on the blob's content
-- A doc-string with the natural language statement from the book
-- Appropriate Mathlib imports
-
-No blueprint-specific annotations are needed — LeanArchitect runs externally with `--all` to extract the blueprint from the compiled `.olean` files.
-
-Example:
-```lean
-/-- **Bolzano-Weierstrass Theorem.** Every bounded sequence in ℝ has a convergent subsequence. -/
-theorem bolzano_weierstrass {s : ℕ → ℝ} (hb : Bornology.IsBounded (Set.range s)) :
-    ∃ φ : ℕ → ℕ, StrictMono φ ∧ ∃ L, Filter.Tendsto (s ∘ φ) Filter.atTop (nhds L) := by
-  sorry
-```
-
-Once scaffolding is complete, run `extract_blueprint single --all --json` against each module's `.olean` to get the blueprint JSON, and `leanblueprint web` to update the HTML dependency graph.
-
-**Output:** `lean/{Title}/Chapter1/Theorem1_1.lean`, etc.
-
-**Verify:** `cd lean && lake build` succeeds (everything compiles with sorries).
-
-### Stage 3.2: Formalization Work Loop
-
-Orchestrate agents to formalize items, respecting the dependency DAG from the blueprint.
+Phases 1 and 2 are analytical work that a single agent (or small number of agents) can complete. Phase 3 is where the bulk of the project happens: every formalizable item needs a Lean file with correct definitions and eventually a complete proof. For a book-length project, each Phase 3 stage requires orchestration across many agents working in parallel via GitHub issues and PRs — the same pattern used in Stage 1.4 for page transcription.
 
 #### PR lifecycle
 
@@ -353,26 +288,167 @@ gh pr list --state open \
 | xargs -I{} gh pr merge {} --squash --delete-branch
 ```
 
+### Stage 3.1: Lean Scaffolding
+
+The Lean project was created at the repo root by `ff init` in Stage 1.2 and Mathlib was built then. Create `.lean` files for each formalizable item (theorems, definitions, lemmas — not discussion blobs).
+
+#### Setup
+
+The orchestrating agent creates the file structure and then creates issues for worker agents:
+
+1. Create the skeleton: root file `{Title}.lean` importing all chapter files, chapter files `{Title}/Chapter1.lean` importing all items in the chapter. Commit this to `main`.
+2. Create `gh label create scaffolding --color 1d76db` (ignore error if exists).
+3. Create one issue per chapter (or per item for chapters with complex definitions):
+   - Title: `Scaffold Chapter N` or `Scaffold <ItemID>`
+   - Body: items from `items.json` to scaffold, with links to blob files and `research/mathlib-coverage.json`
+   - Label: `scaffolding`
+
+#### Agent workflow
+
+Each agent assigned to a scaffolding issue:
+1. Reads the blob files for items in its scope
+2. Reads `research/mathlib-coverage.json` for Mathlib API references
+3. Creates `.lean` files following the conventions below
+4. Submits a PR with auto-merge enabled (see PR lifecycle above)
+
+#### Import chain
+
+Each item gets its own file:
+- Root file: `{Title}.lean` importing all chapter files
+- Chapter files: `{Title}/Chapter1.lean` importing all items in the chapter
+- Item files: `{Title}/Chapter1/Theorem1_1.lean`
+
+#### Definitions vs. theorems: the critical distinction
+
+**Definitions (`def`, `noncomputable def`, `instance`, `abbrev`) must have real bodies — never `sorry`.** A sorry'd definition spoils all subsequent scaffolding. 
+
+**Only theorem/lemma proofs may use `sorry`.** Propositional subterms within a definition (e.g., a proof obligation in a `where` clause or `Subgroup.mk`) may also use `sorry`, since the *data* part of the definition is still constructed. 
+
+Bad (definition-level sorry — the object does not exist):
+```lean
+noncomputable def myMetricSpace (X : Type*) : MetricSpace X := sorry
+```
+
+Good (definition with proof obligation sorry'd — the object exists):
+```lean
+def evenIntegers : AddSubgroup ℤ where
+  carrier := {n | 2 ∣ n}
+  add_mem' := sorry  -- data is constructed, only proofs deferred
+  zero_mem' := sorry
+  neg_mem' := sorry
+```
+
+Good (theorem-level sorry — the statement is meaningful, proof deferred):
+```lean
+/-- **Bolzano-Weierstrass.** Every bounded sequence in ℝ has a convergent subsequence. -/
+theorem bolzano_weierstrass {s : ℕ → ℝ} (hb : Bornology.IsBounded (Set.range s)) :
+    ∃ φ : ℕ → ℕ, StrictMono φ ∧ ∃ L, Filter.Tendsto (s ∘ φ) Filter.atTop (nhds L) := by
+  sorry
+```
+
+Writing definitions is the hardest part of scaffolding. If a definition requires significant research into the API of Mathlib or another library, or careful mathematical design, that work must happen here — not be deferred with a `sorry`. 
+
+Each item file should contain:
+- A doc-string with the natural language statement from the book
+- Appropriate imports from earlier items or library dependencies
+- For definitions: a full construction (proof obligations within the definition may use `sorry`). Auxiliary definitions may be needed, which should happen during scaffolding. 
+- For theorems/lemmas: a sorry'd proof with the precise Lean statement
+
+**Output:** `{Title}/Chapter1/Theorem1_1.lean`, etc.
+
+**Verify:** `lake build` succeeds (everything compiles with sorries).
+
+### Stage 3.2: Scaffolding Review
+
+Before beginning proof work (Stage 3.3), verify that the scaffolding is sound. This gate helps prevent mis-formalizations and definition-level sorries.
+
+#### Setup
+
+Create one issue per chapter for scaffolding review (`gh label create scaffolding-review --color d4c5f9`). Each review agent checks one chapter's items against the checklist below, updates `progress/items.json` with status transitions, and submits a PR with any fixes.
+
+#### Automated check: no definition-level sorries
+
+Scan all `.lean` files for sorry'd definitions — cases where the return value itself (not a proof obligation within a `where` clause) is `sorry`. The key patterns to catch:
+
+```bash
+# Coarse pre-filter — catches common cases but is NOT authoritative
+grep -rn ':= sorry\|:= by sorry' {Title}/ --include='*.lean' | grep -v 'theorem \|lemma '
+```
+
+This grep is a coarse pre-filter only. It misses multiline definitions and some `instance`/`abbrev` layouts. Every match must be manually reviewed, and the reviewer must also inspect all `def`, `noncomputable def`, `instance`, and `abbrev` declarations — not just grep matches.
+
+For each match: if the `sorry` is the *value* of a `def`/`abbrev`/`instance` (the object itself doesn't exist), it must be fixed. If it's a proof obligation inside a `where` block or structure constructor, that's acceptable. Instances follow the same rule as definitions: an `instance Foo where data_field := sorry` is bad (the data doesn't exist), but `instance Foo where proof_field := sorry` is acceptable (the data is constructed, only the proof is deferred).
+
+#### Manual review checklist
+
+A review agent should verify:
+1. **No definition-level sorries** — all `def`, `instance`, and `abbrev` declarations have real data bodies (proof obligations within `where` clauses may use sorry)
+2. **Theorem statements reference correct Mathlib types** — spot-check 10-20% of theorem statements against the blob text and Mathlib API
+3. **Import chain is correct** — `lake build` succeeds
+
+#### Status transitions
+
+After Stage 3.2 review:
+- Items that pass → status `definition_verified` (for both definitions and theorems)
+- Items that fail → status `needs_definition`, with a GitHub issue created
+
+#### Output
+
+- A scaffolding review report in `progress/summaries/scaffolding-review.md`
+- GitHub issues for any definition-level sorries found (these must be fixed before proof work begins)
+- Updated `progress/items.json` with status transitions
+
+### Stage 3.3: Formalization Work Loop
+
+Orchestrate agents to formalize items, respecting the dependency DAG.
+
+#### Formalization guidance
+
+- **Read the book's proof first (mandatory).** Before attempting any proof, read the blob file (`blobs/<Chapter>/<Item>.md`) for the theorem you're proving. Remember that the proof itself is likely to be in separate blob from the statement. The book contains the proof strategy — follow it. Do not invent your own proof approach from mathematical knowledge. The book's approach is chosen to build on earlier results in the book, which are the results available to you.
+- **Follow the book's dependency chain.** If the book says "the result follows from Lemma X.Y.Z", find that lemma in the project and use it in your proof — even if it still has a `sorry`. A sorry'd dependency is not a blocker. Never conclude that a proof is "blocked on missing Mathlib infrastructure" when the book's proof uses an earlier result from the same book.
+- **"Not in Mathlib" is not a blocker.** This project exists to formalize what isn't in Mathlib. If the book's proof requires a result that isn't in Mathlib, check whether it's an earlier item in the book (it usually is). If it genuinely requires external mathematics not covered by the book or Mathlib, prove it here — that's just more work, not a blocker. Only after exhausting the book's own proof path and checking the informal literature should you consider filing an infrastructure issue.
+- **Push sorries earlier:** Work top-down. If the proof of a theorem is currently `sorry`, you can replace this with the intended structure of the proof, even if some subsidiary steps are still `sorry` for now. Don't waste time on proving helper lemmas until you know they're needed, because you've used them in high level proofs later.
+- **Spec-driven development:** Use sorry placeholders with comments explaining what's needed, not `True` or other cheats.
+- **Pre-formalization:** For complex items, first translate the natural language blob into a pedantic, detailed version with careful references to every fact used, before attempting formalization.
+
 #### Agent workflow
 
 Each agent is assigned a task (an item or small group of related items). The agent either:
 1. **Submits a PR** that fully or partially resolves the task (with auto-merge enabled)
-2. **Escalates by posting an issue** documenting the blockers
+2. **Escalates by posting multiple issues** documenting a proposed decomposition into more manageable tasks. These may include doing further research, either within the book (for more proof details, or prerequisites earlier in the book), or in Mathlib, or other informal or formal sources.
 
 #### Task selection
 
-Agents query the blueprint to find ready work:
-1. Run `extract_blueprint single --all --json` against each module to get the current dependency graph and formalization status.
-2. Find nodes that still contain `sorry` but whose dependency nodes are all sorry-free.
-3. These are the items ready for formalization — pick one and work on it.
+Once Stage 3.2 is complete, all statements and definitions are verified. Agents should prioritize the hardest, most impactful items, not items with the easiest dependency graphs.
 
-Status updates are automatic: when an agent removes a `sorry`, the next extraction reflects the new status. No annotations needed in the Lean source. Non-formal nodes (discussion, external dependencies) are tracked via leanblueprint's LaTeX macros and `progress/items.json`.
+Task selection criteria (in priority order):
+1. Items that unblock the most downstream work (high fan-out in the dependency DAG)
+2. Items assessed as mathematically hardest (from health check or summarize reports)
+
+Status updates are tracked in `progress/items.json`. Non-formal nodes (discussion, external dependencies) are also tracked there.
+
+#### Escalation policy: the `blocked` label
+
+**`blocked` means blocked on another issue in *this* repository** — never on missing
+external infrastructure. This project is responsible for formalizing the book in full.
+
+Before applying `blocked`:
+1. **Read the book's proof** in the blob file (`blobs/<Chapter>/<Item>.md`). Identify
+   which earlier results the proof cites — these are your actual dependencies. Check
+   whether those earlier items exist in the project and whether they have sorries.
+2. **Decompose** the problem into sub-tasks matching the book's proof structure, create
+   issues for each, link with `- [ ] depends on #X`, then mark the original blocked on
+   those issues.
+3. **If you can't decompose**, research the informal literature first (textbooks,
+   surveys, lecture notes) to find a proof strategy, then decompose.
+4. **If a result isn't in Mathlib**, prove it here — that's just more work, not a blocker.
+   The book's proof almost certainly uses results from earlier in the book. Check there
+   first.
 
 #### Dependency tracking
 
 - Use `- [ ] depends on #X` comments in issues
-- Use a `blocked` label for items waiting on dependencies
-- Agents should not work on items whose dependencies aren't yet formalized (unless they are willing to sorry the dependencies and work top-down)
+- Use a `blocked` label only for items blocked on a *definition-level* sorry in a dependency — never for proof-level sorries
 
 #### Triage
 
@@ -382,121 +458,106 @@ Specialized triage agents should periodically review open issues for:
 - Dependency ordering mistakes
 - Opportunities for useful tactics or metaprograms
 
-#### Formalization guidance
+#### Periodic status check (every 50 merged PRs)
 
-- **Push sorries earlier:** Work top-down. State the theorem, sorry the proof, then work on filling in the sorry. Don't waste time on helper lemmas until you know they're needed.
-- **Spec-driven development:** Use sorry placeholders with comments explaining what's needed, not `True` or other cheats.
-- **Pre-formalization:** For complex items, first translate the natural language blob into a pedantic, detailed version with careful references to every fact used, before attempting formalization.
+After every 50 merged PRs, a review agent must perform a status check. This prevents the work loop from drifting — agents have tendency to pick the easy work and defer the hardest parts. Status checks that identify remaining work without producing GitHub issues are wasted — the issues are the primary deliverable, not the report.
 
-### Stage 3.3: Dependency Trimming (post-formalization)
+The status check must:
 
-Once items have sorry-free proofs, analyze actual dependencies using both LeanArchitect's inference (for formal declarations) and manual review (for non-formal nodes).
+1. **Scan for definition-level sorries (regression check).** Re-run the Stage 3.2 automated check. New definition-level sorries can be introduced during proof work when agents create helper definitions with sorry bodies. Any found must become issues — these are the highest priority, since they make downstream theorem statements vacuous.
 
-For Lean-backed nodes, LeanArchitect automatically infers dependencies from proof terms — compare these against the conservative initial dependencies. For non-formal nodes (discussion blobs, external dependencies), review whether the initial dependency assumptions were accurate.
+2. **Identify the hardest remaining items.** This is a mathematical assessment, not just a sorry count. For each chapter with remaining work, identify the items that are hardest to complete, considering:
+   - Mathematical depth and complexity (e.g., developing significant theory vs a routine calculation)
+   - Dependency chains (items that unblock many others)
+   - Whether the book's proof strategy requires infrastructure not in Mathlib
+   For each, create or update a GitHub issue with a difficulty assessment, a decomposition into sub-tasks, and concrete next steps.
 
-Compare the inferred/reviewed dependencies against `dependencies/internal.json`:
+3. **Identify neglected items.** List all items with remaining sorries that have had zero PRs and zero issues across recent waves. For each, determine why and create an issue if none exists.
+
+4. **Check work distribution.** Count PRs per chapter over recent waves. If any chapter with remaining sorries has received disproportionately little attention, flag it and create targeted issues for its hardest items.
+
+5. **Update `progress/items.json`** to reflect the current state, especially items whose status has changed but weren't updated.
+
+6. **Create actionable issues.** Every finding from steps 1-4 that doesn't already have a GitHub issue must result in a new issue. Before creating an issue, search open issues for the item ID to avoid duplicates.
+
+**Counting PRs:** Count merged PRs since the last status-check issue was closed. Use `gh pr list --state merged` with a date filter based on the close date of the last `status-check` labeled issue.
+
+**Output:**
+- `progress/summaries/status-check-wave-N.md` with the analysis
+- GitHub issues for every actionable finding (labeled `status-check`)
+
+**The status check is mandatory, not optional.** A planner must schedule it. If no status check has been performed after 50 PRs, the next planner must schedule one before creating new proof work items.
+
+### Stage 3.4: Dependency Trimming (post-formalization)
+
+Once items have sorry-free proofs, analyze actual dependencies by reviewing the proof terms and imports.
+
+Compare the actual dependencies against `dependencies/internal.json`:
 - Which initial dependencies turned out to be unnecessary?
 - Are there unexpected dependencies that weren't in the original analysis?
 - Does the actual dependency structure reveal anything interesting about the book's organization?
 
 This is when we learn the true dependency structure of the book, which may differ significantly from the conservative initial assumption.
 
-**Output:** Updated `dependencies/internal.json` and blueprint reflecting actual dependencies.
+**Output:** Updated `dependencies/internal.json` reflecting actual dependencies.
 
-### Stage 3.4: Proof Polishing
+### Stage 3.5: Proof Polishing
 
-Polish every non-trivial sorry-free proof to Mathlib quality. Open one GitHub issue (labelled `proof-polish`) per proof that needs attention, then work through them systematically using the `proof-polish` skill.
+Polish sorry-free proofs to Mathlib quality standards. This is a cleanup pass — the proofs work, but may be verbose, use suboptimal tactics, or not follow Mathlib conventions.
 
-**Output:** All Lean source files are lint-clean and idiomatic. Every `proof-polish` issue is closed. `progress/items.json` updated with status `proof_polished`.
+#### Setup
 
-**Verify:** `lake build` produces zero linter warnings. Every `proof-polish` issue is closed.
+Create `gh label create proof-polish --color c5def5` (ignore error if exists). Create one issue per chapter (or per item for complex proofs):
+- Title: `Polish proofs in Chapter N` or `Polish <ItemID>`
+- Label: `proof-polish`
 
-### Stage 3.5: Upstreaming Analysis
+#### Agent workflow
 
-Identify formalized results that may be worth contributing to Mathlib or related libraries.
-The output is a non-binding `UPSTREAMING.md` report — no actual upstreaming happens here.
+Each agent assigned to a proof-polish issue:
 
-#### Criteria
+1. Reviews each sorry-free proof in its scope
+2. Applies cleanup:
+   - Combine redundant steps (`rw [a]; rw [b]` → `rw [a, b]`)
+   - Replace verbose tactic sequences with more powerful single tactics where appropriate
+   - Remove unnecessary intermediate steps (test by deleting and checking if the proof still works)
+   - Ensure `simp` calls use minimal lemma sets where practical
+   - Follow Mathlib naming conventions and style
+3. Verifies the polished proof still compiles
+4. Submits a PR with auto-merge enabled
 
-Include only results with **proofs genuinely new to Mathlib**. Exclude:
-- Items whose proof is a one-line call to an existing Mathlib declaration (pure wrappers)
-- Items that combine two or three Mathlib facts with trivial glue
-- Items where the proof quality, generality, or formulation is not at Mathlib level
+#### Status transitions
+
+After polishing: items move from `dependency_trimmed` → `proof_polished` in `progress/items.json`.
+
+**Output:** Polished `.lean` files. Updated `progress/items.json`.
+
+**Verify:** All previously sorry-free items have status `proof_polished`. `lake build` succeeds.
+
+### Stage 3.6: Upstreaming Analysis
+
+Identify formalized results that may be worth contributing to Mathlib. The output is a non-binding `UPSTREAMING.md` report — no actual upstreaming happens here.
 
 #### Phase 1: Lightweight triage
 
-Scan all sorry-free, proof-polished items. For each, make an initial judgment:
-
-- **Reject immediately** if the proof in the Lean file is a one-liner delegating to a named
-  Mathlib theorem — it's already in Mathlib.
-- **Keep as candidate** if the proof is substantive and the result feels absent from Mathlib's
-  API.
-
-Record the initial candidate list with a brief justification for each entry.
+Scan all proof-polished items. Reject immediately if the proof is a one-liner delegating to a named Mathlib theorem, or trivial glue between two or three existing Mathlib facts. Keep as candidate if the proof is substantive and the result appears absent from Mathlib's API.
 
 #### Phase 2: Deep Mathlib research
 
-For each candidate, search the **local Mathlib source** (`.lake/packages/mathlib/`) for
-closely related results — do not rely on web searches or AI knowledge of Mathlib, which
-may be out of date. Open one GitHub issue per candidate to track the research and verdict.
+For each candidate, search the **local Mathlib source** (`.lake/packages/mathlib/`) for closely related results — do not rely on web searches or AI knowledge of Mathlib, which may be out of date. Check for equivalent results under different names, close relatives that make the candidate a straightforward corollary, and proof approaches that reconstruct something Mathlib already proves elsewhere. Open one GitHub issue per candidate to track the research.
 
-For each candidate, determine:
-1. Is the result already in Mathlib, possibly under a different name or with different type
-   class assumptions? (Check related files carefully — not just exact name matches.)
-2. Is there a close relative in Mathlib such that the candidate is just a straightforward
-   corollary or type-class variant?
-3. Is the proof approach genuinely new, or does it reconstruct something Mathlib already
-   proves elsewhere?
+Assign one of three verdicts:
 
-Based on the research, assign one of three verdicts:
-
-- **Reject — insufficient interest:** The result is too narrow, the proof quality doesn't
-  meet Mathlib standards, or it's not a good fit.
-- **Reject — already in Mathlib:** Found an equivalent result. Create a GitHub issue to
-  refactor the proof to use the Mathlib declaration directly, and update the item's
-  `progress/items.json` status to `mathlib_covered`.
-- **Include in UPSTREAMING.md:** Genuinely new to Mathlib, correct, and at appropriate
-  generality and quality.
-
-#### Phase 3: Write UPSTREAMING.md
-
-Write `UPSTREAMING.md` at the repository root with the following structure:
-
-```markdown
-# Upstreaming Candidates
-
-These are suggestions only — no actual upstreaming has occurred.
-
-## Included
-
-### <Item ID> — `theorem_name`
-
-**File:** `path/to/Item.lean`
-
-**Statement:** (the Lean statement)
-
-**Why it's new:** What was searched, what was found, why this is absent.
-
-**Suggested home:** Which Mathlib file/module it belongs in.
-
-## Excluded
-
-### <Item ID> — reason
-
-One-line reason (already in Mathlib as `FooBar.baz`, too narrow, etc.).
-```
+- **Reject — already in Mathlib:** Create a GitHub issue to refactor the proof to use the Mathlib declaration directly, and set `upstreaming_status` to `mathlib_covered`.
+- **Reject — insufficient interest:** Too narrow, not at Mathlib quality/generality, or not a good fit.
+- **Include in UPSTREAMING.md:** Genuinely new to Mathlib, correct, and at appropriate generality.
 
 #### Output
 
-- `UPSTREAMING.md` at the repository root
-- GitHub issues for any items whose proofs should be refactored to use Mathlib directly
-- `progress/items.json` updated with `"upstreaming_status"` field:
-  - `"candidate"` — included in UPSTREAMING.md
-  - `"mathlib_covered"` — already in Mathlib, refactor issue opened
-  - `"rejected"` — not a candidate
+Write `UPSTREAMING.md` at the repository root. For each included candidate: the item ID, Lean declaration name, file path, Lean statement, why it's new (what was searched, what was found), and suggested Mathlib module. For excluded items: one-line reason each.
 
-**Verify:** `UPSTREAMING.md` exists. Every proof-polished item has an `upstreaming_status`
-in `progress/items.json`.
+Update `progress/items.json` with `"upstreaming_status"`: `"candidate"`, `"mathlib_covered"`, or `"rejected"`.
+
+**Verify:** `UPSTREAMING.md` exists. Every proof-polished item has an `upstreaming_status` in `progress/items.json`.
 
 ---
 
@@ -552,7 +613,11 @@ Commits made during a turn should mention the corresponding progress file in the
 ### Item-level progress: `progress/items.json`
 
 Item statuses flow through:
-`identified` → `extracted` → `statement_formalized` → `proof_formalized` → `sorry_free` → `dependency_trimmed` → `proof_polished`
+`identified` → `extracted` → `scaffolded` → `definition_verified` → `proof_formalized` → `sorry_free` → `dependency_trimmed` → `proof_polished`
+
+Special statuses (set during review):
+- `needs_definition` — the item has a definition-level sorry that must be resolved before downstream theorems are meaningful
+- `attention_needed` — requires specialized agent attention (e.g., wrong statement, repeated failures)
 
 ```json
 {


### PR DESCRIPTION
## Summary

Update template files (PLAN.md, .claude/CLAUDE.md, .gitignore) to the latest versions from the FormalFrontier pipeline.

## Changes

```diff
diff --git a/.claude/CLAUDE.md b/.claude/CLAUDE.md
index b529e2f..b4ad2ca 100644
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -18,52 +18,35 @@ Push sorries earlier. State the theorem first, sorry the proof, then fill in. Do
 ### Spec-Driven Development
 Use `sorry` placeholders with comments explaining what's needed. Never use `True` as a placeholder for propositions — it hides the actual requirements and will need a full refactor to fix.
 
+### Definitions Must Be Constructed
+**Never sorry the body of a `def`, `noncomputable def`, `instance`, or `abbrev`.** A sorry'd definition means the mathematical object does not exist — any theorem referencing it is vacuous. Proof obligations *within* a definition (e.g., `where` clauses) may use sorry, but the data itself must be real. See Stage 3.1 in PLAN.md for details and examples.
+
 ### Discussion Blobs Are First-Class
 During structure analysis (Stage 1.5), unstructured text between numbered items must be identified and tracked just like theorems and definitions. These discussion paragraphs carry context that proofs depend on. Every byte of the book must belong to exactly one blob.
 
 ### Conservative Dependencies
-Store only **direct** dependencies. The conservative default is a linear chain: each item depends only on its immediate predecessor. Never store transitive closure — that creates an O(N²) file with no useful information. We trim to actual direct dependencies later (Stage 3.3) once proofs exist.
+Store only **direct** dependencies. The conservative default is a linear chain: each item depends only on its immediate predecessor. Never store transitive closure — that creates an O(N²) file with no useful information. We trim to actual direct dependencies later (Stage 3.4) once proofs exist.
 
 ## When Stuck
 
-- **3 failed proof attempts**: escalate the proof to Aristotle (see below), then if that also fails, document in a GitHub issue and move on
-- **3 failed attempts on a non-proof sub-task** (definitions, statement formalization): skip it, document in a GitHub issue, move on (Aristotle only handles proofs)
-- **Dependency blocked:** Post an issue with `- [ ] depends on #X` and add the `blocked` label
-- **Definition seems wrong:** Post an issue describing the problem — don't silently work around bad definitions
-- **Missing Mathlib API:** Post an issue describing what's needed; another agent or human can add it
-- **Ordering mistake in the plan:** Report it — request a replan rather than hacking around it
-
-## Aristotle Escalation
-
-Aristotle is an automated theorem prover. Escalate to it when Claude can't prove a theorem after 2-3 serious attempts.
-
-### When to use Aristotle
+### Read the book first (mandatory)
 
-- A proof is beyond Claude's ability after multiple attempts
-- Standard mathematical proofs (calculus, algebra, analysis) that follow well-known patterns
-- Batch proving: after Stage 3.1 scaffolding, submit all sorry'd theorems
+**Before attempting any proof**, read the blob file for the item (`blobs/<Chapter>/<Item>.md`). The book contains the proof strategy — follow it. Do not invent your own proof approach from mathematical knowledge.
 
-### When NOT to use Aristotle
+If the book's proof says "by Lemma X.Y.Z" or "the result follows from [earlier result]":
+1. Find that earlier result in the project (search `blobs/` and the Lean files)
+2. Use it in your proof — even if it still has a `sorry`. A sorry'd dependency is not a blocker.
 
-- Statement formalization (translating definitions/theorem statements from natural language) — Claude handles this
-- When the formalized statement might be wrong — fix the statement first
-- For discussion blobs or non-theorem items
+**Never say "not in Mathlib" without first checking the book.** The book's proofs build on earlier results in the book. Those results are what you should be using — not searching Mathlib for advanced infrastructure like Schur functors or Schur-Weyl duality when the book uses an elementary lemma from the previous page.
 
-### Handoff protocol
+### Escalation ladder
 
-1. Create a temporary copy of the item's Lean file (preserving all imports, namespaces, notation). Keep exactly one `sorry` (the target proof); change all others to `admit`.
-2. Gather context files: sorry-free local Lean files from the import chain (skip Mathlib imports). If no local files are sorry-free yet, submit with no context files.
-3. Submit: `aristotle prove-from-file item_pending.lean --no-wait --no-auto-add-imports --context-files ...`
-4. Record the project ID in `progress/items.json` with status `sent_to_aristotle`
-5. Delete the temp file — never commit `admit`
-
-**Deduplication:** Before submitting, check that the item is not already in `sent_to_aristotle` status. Only one submission per item at a time.
-
-### After Aristotle returns
-
-- **Success:** Verify the proof compiles (`lake env lean`), copy into the item's Lean file, update status to `sorry_free` (if all sorries resolved) or `proof_formalized`
-- **False statement:** Mark `attention_needed`, post a GitHub issue with the counterexample — the formalized statement needs fixing
-- **Failure/timeout/version mismatch:** Mark `attention_needed`, move on
+- **3 failed attempts on any sub-task** (proof, definition construction, statement formalization): document in a GitHub issue and move on
+- **Dependency blocked:** Post an issue with `- [ ] depends on #X` and add the `blocked` label — but only for *definition-level* blockers, never for proof-level sorries
+- **Definition seems wrong:** Post an issue describing the problem — don't silently work around bad definitions
+- **Definition-level sorry found:** This is highest priority. The mathematical object must be constructed — see "Definitions Must Be Constructed" above. Create an issue and fix it before proving downstream theorems.
+- **Missing Mathlib API:** First check whether the missing result is an earlier item in the book. If it is, that's a dependency, not a missing Mathlib API. If genuinely missing from Mathlib, **prove it here** — that's the highest-priority work, not a reason to defer. This project exists to formalize what isn't in Mathlib.
+- **Ordering mistake in the plan:** Report it — request a replan rather than hacking around it
 
 ## PR Workflow
 
@@ -98,7 +81,6 @@ Never skip this step. Downstream agents are blocked on `main` until merged PRs l
 - **Per-turn handoff files:** `progress/YYYY-MM-DDTHH-MM-SSZ.md` (UTC timestamp)
 - Stage-level summary: `PROGRESS.md` (optional, human-facing)
 - Item-level: `progress/items.json`
-- Formalization status: tracked in `progress/items.json`
 - Do NOT modify `PLAN.md` — it is the reference plan
 - Blockers and discussion: GitHub issues
 
diff --git a/.gitignore b/.gitignore
index acee8bc..f96c75d 100644
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/.lake
-.pod/
-sessions/
-worktrees/
+.lake/
+lake-packages/
+build/
+.DS_Store
diff --git a/PLAN.md b/PLAN.md
index ed240eb..7c62864 100644
--- a/PLAN.md
+++ b/PLAN.md
@@ -19,21 +19,15 @@ pdfseparate source/original.pdf pdf/raw-pages/%d.pdf
 
 ### Stage 1.2: Start Lean Build
 
-The `lean/` directory was created by `ff init` using `lake init <ProjectName> math`, where `<ProjectName>` is the repository name with the `FormalFrontier-` prefix stripped (e.g., `FormalFrontier-Rudin` → `Rudin`). Start downloading Mathlib now so it is ready by the time formalization begins.
+The Lean project was created at the repo root by `ff init` using `lake init <ProjectName> math`, where `<ProjectName>` is the repository name with the `FormalFrontier-` prefix stripped (e.g., `FormalFrontier-Rudin` → `Rudin`). Start downloading Mathlib now so it is ready by the time formalization begins.
 
 ```bash
-cd lean && lake build
+lake exe cache get &&  lake build
 ```
 
-This takes ~30 minutes the first time (Mathlib download and build). Start it in the background and proceed with the remaining Phase 1 stages. Having the Lean project available early allows agents to test Lean snippets while transcribing and analyzing structure.
-
-**Output:** `lean/.lake/` with compiled Mathlib artifacts.
-
-**Verify:** `cd lean && lake build` exits successfully.
-
 ### Stage 1.3: Frontmatter Detection
 
-This is a **lightweight pass**. Start by examining the first ~20 pages and the last ~10 pages of `pdf/raw-pages/` — that is usually sufficient. If a book has an unusually long preface, TOC, or index, look at a few more pages until the boundary is clear. You do not need to read the entire book.
+Start by examining the first ~20 pages and the last ~10 pages of `pdf/raw-pages/` — that is usually sufficient. If a book has an unusually long preface, TOC, or index, look at a few more pages until the boundary is clear. You do not need to read the entire book.
 
 Determine:
 - Where "page 1" of the book actually starts (after title page, copyright, table of contents, preface, etc.)
@@ -46,7 +40,7 @@ Copy pages into `pdf/pages/` with the appropriate names. (`pdf/raw-pages/` is th
 
 **All pages are included** — frontmatter, main content, and backmatter all get entries in `pdf/pages/`. Nothing is discarded.
 
-After copying, write `pdf/pages/mapping.json` recording the raw-page → logical-page correspondence. This is the authoritative record of the frontmatter boundary decision; subsequent stages that need to map between raw and logical page numbers must read this file rather than reverse-engineering it from filenames.
+After copying, write `pdf/pages/mapping.json` recording the raw-page → logical-page correspondence. 
 
 Format:
 ```json
@@ -129,6 +123,7 @@ Identify every piece of content in the book and assign it to a blob. The goal is
 
 **Formally numbered items:**
 - Theorems, lemmas, propositions, corollaries
+- Proofs of theorems, lemmas, and propositions
 - Definitions
 - Examples, exercises
 - Remarks, notes
@@ -224,37 +219,9 @@ Categorize each:
 
 **Output:** `dependencies/external.json` — a list of external dependencies, each with a description, the items that need it, and the category.
 
-### Stage 2.3: Blueprint Assembly
-
-Combine `items.json`, `dependencies/internal.json`, and `dependencies/external.json` into a preliminary blueprint.
-
-This is a DAG of what needs to be formalized and in what order. Because the initial dependencies form a linear chain (each item depends only on its immediate predecessor), the initial DAG is a single path. That is fine — it will be refined in Stage 3.3.
-
-#### Blueprint tooling
-
-The blueprint uses a hybrid of two tools:
-
-- **leanblueprint** (https://github.com/PatrickMassot/leanblueprint): The rendering substrate. Produces an interactive HTML website with a dependency DAG and a PDF document. Uses LaTeX source with special macros (`\uses{}`, `\lean{}`, `\leanok`). This handles **all** blueprint nodes — both formal declarations and non-formal content (discussion blobs, introductions, external dependencies).
-- **LeanArchitect** (https://github.com/hanwenzhu/LeanArchitect, using https://github.com/kim-em/LeanArchitect/tree/blueprint-all until https://github.com/hanwenzhu/LeanArchitect/pull/8 is merged): Complements leanblueprint for Lean-backed nodes. Run externally with `extract_blueprint --all` against the project's compiled `.olean` files — no `require`, `import`, or attributes needed in the Lean source. Automatically infers dependencies between formal declarations and tracks formalization status via sorry detection. Provides JSON export for agent consumption.
-
-The split: leanblueprint owns the full DAG (formal + non-formal nodes). LeanArchitect automates the Lean-backed portion (theorems, definitions, lemmas), eliminating manual `\leanok` and `\uses{}` maintenance for those nodes. Non-formal nodes (discussion, introductions, external dependencies) use leanblueprint's LaTeX macros directly. The Lean source files are completely free of blueprint annotations.
-
-#### Steps
-
-1. Set up leanblueprint scaffolding in `blueprint/` (use `leanblueprint new` or copy from a template).
-2. Generate LaTeX blueprint nodes from `items.json` and dependency data. Each item becomes a LaTeX environment with `\label{}` and `\uses{}` annotations.
-3. Non-formalizable items (discussion, introduction, etc.) are included as LaTeX nodes for completeness — they appear in the DAG but don't need Lean declarations.
-4. Run `leanblueprint web` to generate the HTML dependency graph.
-
-The initial blueprint is purely LaTeX-based. LeanArchitect integration happens after Stage 3.1 when Lean scaffolding is compiled — run `extract_blueprint --all --json` against the `.olean` files to get the dependency graph and formalization status.
-
-**Output:** `blueprint/` directory with leanblueprint LaTeX source files.
-
-**Verify:** `leanblueprint web` succeeds and produces a valid dependency graph.
-
-### Stage 2.4: Research — Mathlib Coverage
+### Stage 2.3: Research — Mathlib Coverage
 
-For each external dependency and each item, search Mathlib for relevant material.
+For each external dependency and each item, search Mathlib for relevant material. For large books, orchestrate this via issues (one per chapter) so that multiple agents can research in parallel.
 
 - Is this definition already in Mathlib? Under what name?
 - Is this theorem already proved? At what generality?
@@ -262,7 +229,7 @@ For each external dependency and each item, search Mathlib for relevant material
 
 **Output:** `research/mathlib-coverage.json` — mapping items and external deps to Mathlib declarations (with `#check` names).
 
-### Stage 2.5: Research — External Sources
+### Stage 2.4: Research — External Sources
 
 For items and dependencies not covered by Mathlib:
 
@@ -272,7 +239,7 @@ For items and dependencies not covered by Mathlib:
 
 **Output:** `research/external-sources.json`
 
-### Stage 2.6: Readiness Report
+### Stage 2.5: Readiness Report
 
 Prepare a human-readable report summarizing:
 
@@ -283,9 +250,9 @@ Prepare a human-readable report summarizing:
 
 **Output:** `READINESS.md`
 
-**Note:** This report is informational — do not pause for human review. Write the report and immediately continue to Stage 2.7.
+**Note:** This report is informational — do not pause for human review. Write the report and immediately continue to Stage 2.6.
 
-### Stage 2.7: Reference Attachment
+### Stage 2.6: Reference Attachment
 
 For each blob that has external dependencies or Mathlib matches, create a companion reference file.
 
@@ -297,82 +264,191 @@ These files are read by formalization agents when they work on the corresponding
 
 ## Phase 3: Formalization
 
+Phases 1 and 2 are analytical work that a single agent (or small number of agents) can complete. Phase 3 is where the bulk of the project happens: every formalizable item needs a Lean file with correct definitions and eventually a complete proof. For a book-length project, each Phase 3 stage requires orchestration across many agents working in parallel via GitHub issues and PRs — the same pattern used in Stage 1.4 for page transcription.
+
+#### PR lifecycle
+
+PRs must be merged to `main` without human intervention to avoid blocking downstream agents. Every PR should have auto-merge enabled at creation time:
+
+```bash
+gh pr create --title "Formalize <ItemID>" --body "..."
+PR_NUM=$(gh pr view --json number --jq .number)
+gh pr merge "$PR_NUM" --auto --squash
+```
+
+At the **start of every planning cycle**, before selecting new work, merge all PRs that are mergeable and have no failing CI checks:
+
+```bash
+gh pr list --state open \
+  --json number,mergeable,statusCheckRollup \
+  --jq '.[] | select(
+    .mergeable == "MERGEABLE" and
+    (.statusCheckRollup | all(.conclusion != "FAILURE" and .conclusion != "CANCELLED"))
+  ) | .number' \
+| xargs -I{} gh pr merge {} --squash --delete-branch
+```
+
 ### Stage 3.1: Lean Scaffolding
 
-The `lean/` project was created by `ff init` in Stage 1.2 and Mathlib was built then. Create `.lean` files for each formalizable item (theorems, definitions, lemmas — not discussion blobs).
+The Lean project was created at the repo root by `ff init` in Stage 1.2 and Mathlib was built then. Create `.lean` files for each formalizable item (theorems, definitions, lemmas — not discussion blobs).
 
-Set up the import chain:
-- Root file: `lean/{Title}.lean` importing all chapter files
-- Chapter files: `lean/{Title}/Chapter1.lean` importing all items in the chapter
-- Item files: `lean/{Title}/Chapter1/Theorem1_1.lean` with a sorry'd statement
+#### Setup
 
-Each item file should contain:
-- A sorry'd `theorem` or `def` statement based on the blob's content
-- A doc-string with the natural language statement from the book
-- Appropriate Mathlib imports
+The orchestrating agent creates the file structure and then creates issues for worker agents:
+
+1. Create the skeleton: root file `{Title}.lean` importing all chapter files, chapter files `{Title}/Chapter1.lean` importing all items in the chapter. Commit this to `main`.
+2. Create `gh label create scaffolding --color 1d76db` (ignore error if exists).
+3. Create one issue per chapter (or per item for chapters with complex definitions):
+   - Title: `Scaffold Chapter N` or `Scaffold <ItemID>`
+   - Body: items from `items.json` to scaffold, with links to blob files and `research/mathlib-coverage.json`
+   - Label: `scaffolding`
+
+#### Agent workflow
+
+Each agent assigned to a scaffolding issue:
+1. Reads the blob files for items in its scope
+2. Reads `research/mathlib-coverage.json` for Mathlib API references
+3. Creates `.lean` files following the conventions below
+4. Submits a PR with auto-merge enabled (see PR lifecycle above)
 
-No blueprint-specific annotations are needed — LeanArchitect runs externally with `--all` to extract the blueprint from the compiled `.olean` files.
+#### Import chain
 
-Example:
+Each item gets its own file:
+- Root file: `{Title}.lean` importing all chapter files
+- Chapter files: `{Title}/Chapter1.lean` importing all items in the chapter
+- Item files: `{Title}/Chapter1/Theorem1_1.lean`
+
+#### Definitions vs. theorems: the critical distinction
+
+**Definitions (`def`, `noncomputable def`, `instance`, `abbrev`) must have real bodies — never `sorry`.** A sorry'd definition spoils all subsequent scaffolding. 
+
+**Only theorem/lemma proofs may use `sorry`.** Propositional subterms within a definition (e.g., a proof obligation in a `where` clause or `Subgroup.mk`) may also use `sorry`, since the *data* part of the definition is still constructed. 
+
+Bad (definition-level sorry — the object does not exist):
+```lean
+noncomputable def myMetricSpace (X : Type*) : MetricSpace X := sorry
+```
+
+Good (definition with proof obligation sorry'd — the object exists):
 ```lean
-/-- **Bolzano-Weierstrass Theorem.** Every bounded sequence in ℝ has a convergent subsequence. -/
+def evenIntegers : AddSubgroup ℤ where
+  carrier := {n | 2 ∣ n}
+  add_mem' := sorry  -- data is constructed, only proofs deferred
+  zero_mem' := sorry
+  neg_mem' := sorry
+```
+
+Good (theorem-level sorry — the statement is meaningful, proof deferred):
+```lean
+/-- **Bolzano-Weierstrass.** Every bounded sequence in ℝ has a convergent subsequence. -/
 theorem bolzano_weierstrass {s : ℕ → ℝ} (hb : Bornology.IsBounded (Set.range s)) :
     ∃ φ : ℕ → ℕ, StrictMono φ ∧ ∃ L, Filter.Tendsto (s ∘ φ) Filter.atTop (nhds L) := by
   sorry
 ```
 
-Once scaffolding is complete, run `extract_blueprint single --all --json` against each module's `.olean` to get the blueprint JSON, and `leanblueprint web` to update the HTML dependency graph.
+Writing definitions is the hardest part of scaffolding. If a definition requires significant research into the API of Mathlib or another library, or careful mathematical design, that work must happen here — not be deferred with a `sorry`. 
 
-**Output:** `lean/{Title}/Chapter1/Theorem1_1.lean`, etc.
+Each item file should contain:
+- A doc-string with the natural language statement from the book
+- Appropriate imports from earlier items or library dependencies
+- For definitions: a full construction (proof obligations within the definition may use `sorry`). Auxiliary definitions may be needed, which should happen during scaffolding. 
+- For theorems/lemmas: a sorry'd proof with the precise Lean statement
 
-**Verify:** `cd lean && lake build` succeeds (everything compiles with sorries).
+**Output:** `{Title}/Chapter1/Theorem1_1.lean`, etc.
 
-### Stage 3.2: Formalization Work Loop
+**Verify:** `lake build` succeeds (everything compiles with sorries).
 
-Orchestrate agents to formalize items, respecting the dependency DAG from the blueprint.
+### Stage 3.2: Scaffolding Review
 
-#### PR lifecycle
+Before beginning proof work (Stage 3.3), verify that the scaffolding is sound. This gate helps prevent mis-formalizations and definition-level sorries.
 
-PRs must be merged to `main` without human intervention to avoid blocking downstream agents. Every PR should have auto-merge enabled at creation time:
+#### Setup
 
-```bash
-gh pr create --title "Formalize <ItemID>" --body "..."
-PR_NUM=$(gh pr view --json number --jq .number)
-gh pr merge "$PR_NUM" --auto --squash
-```
+Create one issue per chapter for scaffolding review (`gh label create scaffolding-review --color d4c5f9`). Each review agent checks one chapter's items against the checklist below, updates `progress/items.json` with status transitions, and submits a PR with any fixes.
 
-At the **start of every planning cycle**, before selecting new work, merge all PRs that are mergeable and have no failing CI checks:
+#### Automated check: no definition-level sorries
+
+Scan all `.lean` files for sorry'd definitions — cases where the return value itself (not a proof obligation within a `where` clause) is `sorry`. The key patterns to catch:
 
 ```bash
-gh pr list --state open \
-  --json number,mergeable,statusCheckRollup \
-  --jq '.[] | select(
-    .mergeable == "MERGEABLE" and
-    (.statusCheckRollup | all(.conclusion != "FAILURE" and .conclusion != "CANCELLED"))
-  ) | .number' \
-| xargs -I{} gh pr merge {} --squash --delete-branch
+# Coarse pre-filter — catches common cases but is NOT authoritative
+grep -rn ':= sorry\|:= by sorry' {Title}/ --include='*.lean' | grep -v 'theorem \|lemma '
 ```
 
+This grep is a coarse pre-filter only. It misses multiline definitions and some `instance`/`abbrev` layouts. Every match must be manually reviewed, and the reviewer must also inspect all `def`, `noncomputable def`, `instance`, and `abbrev` declarations — not just grep matches.
+
+For each match: if the `sorry` is the *value* of a `def`/`abbrev`/`instance` (the object itself doesn't exist), it must be fixed. If it's a proof obligation inside a `where` block or structure constructor, that's acceptable. Instances follow the same rule as definitions: an `instance Foo where data_field := sorry` is bad (the data doesn't exist), but `instance Foo where proof_field := sorry` is acceptable (the data is constructed, only the proof is deferred).
+
+#### Manual review checklist
+
+A review agent should verify:
+1. **No definition-level sorries** — all `def`, `instance`, and `abbrev` declarations have real data bodies (proof obligations within `where` clauses may use sorry)
+2. **Theorem statements reference correct Mathlib types** — spot-check 10-20% of theorem statements against the blob text and Mathlib API
+3. **Import chain is correct** — `lake build` succeeds
+
+#### Status transitions
+
+After Stage 3.2 review:
+- Items that pass → status `definition_verified` (for both definitions and theorems)
+- Items that fail → status `needs_definition`, with a GitHub issue created
+
+#### Output
+
+- A scaffolding review report in `progress/summaries/scaffolding-review.md`
+- GitHub issues for any definition-level sorries found (these must be fixed before proof work begins)
+- Updated `progress/items.json` with status transitions
+
+### Stage 3.3: Formalization Work Loop
+
+Orchestrate agents to formalize items, respecting the dependency DAG.
+
+#### Formalization guidance
+
+- **Read the book's proof first (mandatory).** Before attempting any proof, read the blob file (`blobs/<Chapter>/<Item>.md`) for the theorem you're proving. Remember that the proof itself is likely to be in separate blob from the statement. The book contains the proof strategy — follow it. Do not invent your own proof approach from mathematical knowledge. The book's approach is chosen to build on earlier results in the book, which are the results available to you.
+- **Follow the book's dependency chain.** If the book says "the result follows from Lemma X.Y.Z", find that lemma in the project and use it in your proof — even if it still has a `sorry`. A sorry'd dependency is not a blocker. Never conclude that a proof is "blocked on missing Mathlib infrastructure" when the book's proof uses an earlier result from the same book.
+- **"Not in Mathlib" is not a blocker.** This project exists to formalize what isn't in Mathlib. If the book's proof requires a result that isn't in Mathlib, check whether it's an earlier item in the book (it usually is). If it genuinely requires external mathematics not covered by the book or Mathlib, prove it here — that's just more work, not a blocker. Only after exhausting the book's own proof path and checking the informal literature should you consider filing an infrastructure issue.
+- **Push sorries earlier:** Work top-down. If the proof of a theorem is currently `sorry`, you can replace this with the intended structure of the proof, even if some subsidiary steps are still `sorry` for now. Don't waste time on proving helper lemmas until you know they're needed, because you've used them in high level proofs later.
+- **Spec-driven development:** Use sorry placeholders with comments explaining what's needed, not `True` or other cheats.
+- **Pre-formalization:** For complex items, first translate the natural language blob into a pedantic, detailed version with careful references to every fact used, before attempting formalization.
+
 #### Agent workflow
 
 Each agent is assigned a task (an item or small group of related items). The agent either:
 1. **Submits a PR** that fully or partially resolves the task (with auto-merge enabled)
-2. **Escalates by posting an issue** documenting the blockers
+2. **Escalates by posting multiple issues** documenting a proposed decomposition into more manageable tasks. These may include doing further research, either within the book (for more proof details, or prerequisites earlier in the book), or in Mathlib, or other informal or formal sources.
 
 #### Task selection
 
-Agents query the blueprint to find ready work:
-1. Run `extract_blueprint single --all --json` against each module to get the current dependency graph and formalization status.
-2. Find nodes that still contain `sorry` but whose dependency nodes are all sorry-free.
-3. These are the items ready for formalization — pick one and work on it.
+Once Stage 3.2 is complete, all statements and definitions are verified. Agents should prioritize the hardest, most impactful items, not items with the easiest dependency graphs.
+
+Task selection criteria (in priority order):
+1. Items that unblock the most downstream work (high fan-out in the dependency DAG)
+2. Items assessed as mathematically hardest (from health check or summarize reports)
+
+Status updates are tracked in `progress/items.json`. Non-formal nodes (discussion, external dependencies) are also tracked there.
 
-Status updates are automatic: when an agent removes a `sorry`, the next extraction reflects the new status. No annotations needed in the Lean source. Non-formal nodes (discussion, external dependencies) are tracked via leanblueprint's LaTeX macros and `progress/items.json`.
+#### Escalation policy: the `blocked` label
+
+**`blocked` means blocked on another issue in *this* repository** — never on missing
+external infrastructure. This project is responsible for formalizing the book in full.
+
+Before applying `blocked`:
+1. **Read the book's proof** in the blob file (`blobs/<Chapter>/<Item>.md`). Identify
+   which earlier results the proof cites — these are your actual dependencies. Check
+   whether those earlier items exist in the project and whether they have sorries.
+2. **Decompose** the problem into sub-tasks matching the book's proof structure, create
+   issues for each, link with `- [ ] depends on #X`, then mark the original blocked on
+   those issues.
+3. **If you can't decompose**, research the informal literature first (textbooks,
+   surveys, lecture notes) to find a proof strategy, then decompose.
+4. **If a result isn't in Mathlib**, prove it here — that's just more work, not a blocker.
+   The book's proof almost certainly uses results from earlier in the book. Check there
+   first.
 
 #### Dependency tracking
 
 - Use `- [ ] depends on #X` comments in issues
-- Use a `blocked` label for items waiting on dependencies
-- Agents should not work on items whose dependencies aren't yet formalized (unless they are willing to sorry the dependencies and work top-down)
+- Use a `blocked` label only for items blocked on a *definition-level* sorry in a dependency — never for proof-level sorries
 
 #### Triage
 
@@ -382,121 +458,106 @@ Specialized triage agents should periodically review open issues for:
 - Dependency ordering mistakes
 - Opportunities for useful tactics or metaprograms
 
-#### Formalization guidance
+#### Periodic status check (every 50 merged PRs)
 
-- **Push sorries earlier:** Work top-down. State the theorem, sorry the proof, then work on filling in the sorry. Don't waste time on helper lemmas until you know they're needed.
-- **Spec-driven development:** Use sorry placeholders with comments explaining what's needed, not `True` or other cheats.
-- **Pre-formalization:** For complex items, first translate the natural language blob into a pedantic, detailed version with careful references to every fact used, before attempting formalization.
-
-### Stage 3.3: Dependency Trimming (post-formalization)
+After every 50 merged PRs, a review agent must perform a status check. This prevents the work loop from drifting — agents have tendency to pick the easy work and defer the hardest parts. Status checks that identify remaining work without producing GitHub issues are wasted — the issues are the primary deliverable, not the report.
 
-Once items have sorry-free proofs, analyze actual dependencies using both LeanArchitect's inference (for formal declarations) and manual review (for non-formal nodes).
+The status check must:
 
-For Lean-backed nodes, LeanArchitect automatically infers dependencies from proof terms — compare these against the conservative initial dependencies. For non-formal nodes (discussion blobs, external dependencies), review whether the initial dependency assumptions were accurate.
+1. **Scan for definition-level sorries (regression check).** Re-run the Stage 3.2 automated check. New definition-level sorries can be introduced during proof work when agents create helper definitions with sorry bodies. Any found must become issues — these are the highest priority, since they make downstream theorem statements vacuous.
 
-Compare the inferred/reviewed dependencies against `dependencies/internal.json`:
-- Which initial dependencies turned out to be unnecessary?
-- Are there unexpected dependencies that weren't in the original analysis?
-- Does the actual dependency structure reveal anything interesting about the book's organization?
-
-This is when we learn the true dependency structure of the book, which may differ significantly from the conservative initial assumption.
+2. **Identify the hardest remaining items.** This is a mathematical assessment, not just a sorry count. For each chapter with remaining work, identify the items that are hardest to complete, considering:
+   - Mathematical depth and complexity (e.g., developing significant theory vs a routine calculation)
+   - Dependency chains (items that unblock many others)
+   - Whether the book's proof strategy requires infrastructure not in Mathlib
+   For each, create or update a GitHub issue with a difficulty assessment, a decomposition into sub-tasks, and concrete next steps.
 
-**Output:** Updated `dependencies/internal.json` and blueprint reflecting actual dependencies.
+3. **Identify neglected items.** List all items with remaining sorries that have had zero PRs and zero issues across recent waves. For each, determine why and create an issue if none exists.
 
-### Stage 3.4: Proof Polishing
+4. **Check work distribution.** Count PRs per chapter over recent waves. If any chapter with remaining sorries has received disproportionately little attention, flag it and create targeted issues for its hardest items.
 
-Polish every non-trivial sorry-free proof to Mathlib quality. Open one GitHub issue (labelled `proof-polish`) per proof that needs attention, then work through them systematically using the `proof-polish` skill.
+5. **Update `progress/items.json`** to reflect the current state, especially items whose status has changed but weren't updated.
 
-**Output:** All Lean source files are lint-clean and idiomatic. Every `proof-polish` issue is closed. `progress/items.json` updated with status `proof_polished`.
+6. **Create actionable issues.** Every finding from steps 1-4 that doesn't already have a GitHub issue must result in a new issue. Before creating an issue, search open issues for the item ID to avoid duplicates.
 
-**Verify:** `lake build` produces zero linter warnings. Every `proof-polish` issue is closed.
+**Counting PRs:** Count merged PRs since the last status-check issue was closed. Use `gh pr list --state merged` with a date filter based on the close date of the last `status-check` labeled issue.
 
-### Stage 3.5: Upstreaming Analysis
+**Output:**
+- `progress/summaries/status-check-wave-N.md` with the analysis
+- GitHub issues for every actionable finding (labeled `status-check`)
 
-Identify formalized results that may be worth contributing to Mathlib or related libraries.
-The output is a non-binding `UPSTREAMING.md` report — no actual upstreaming happens here.
+**The status check is mandatory, not optional.** A planner must schedule it. If no status check has been performed after 50 PRs, the next planner must schedule one before creating new proof work items.
 
-#### Criteria
+### Stage 3.4: Dependency Trimming (post-formalization)
 
-Include only results with **proofs genuinely new to Mathlib**. Exclude:
-- Items whose proof is a one-line call to an existing Mathlib declaration (pure wrappers)
-- Items that combine two or three Mathlib facts with trivial glue
-- Items where the proof quality, generality, or formulation is not at Mathlib level
+Once items have sorry-free proofs, analyze actual dependencies by reviewing the proof terms and imports.
 
-#### Phase 1: Lightweight triage
+Compare the actual dependencies against `dependencies/internal.json`:
+- Which initial dependencies turned out to be unnecessary?
+- Are there unexpected dependencies that weren't in the original analysis?
+- Does the actual dependency structure reveal anything interesting about the book's organization?
 
-Scan all sorry-free, proof-polished items. For each, make an initial judgment:
+This is when we learn the true dependency structure of the book, which may differ significantly from the conservative initial assumption.
 
-- **Reject immediately** if the proof in the Lean file is a one-liner delegating to a named
-  Mathlib theorem — it's already in Mathlib.
-- **Keep as candidate** if the proof is substantive and the result feels absent from Mathlib's
-  API.
+**Output:** Updated `dependencies/internal.json` reflecting actual dependencies.
 
-Record the initial candidate list with a brief justification for each entry.
+### Stage 3.5: Proof Polishing
 
-#### Phase 2: Deep Mathlib research
+Polish sorry-free proofs to Mathlib quality standards. This is a cleanup pass — the proofs work, but may be verbose, use suboptimal tactics, or not follow Mathlib conventions.
 
-For each candidate, search the **local Mathlib source** (`.lake/packages/mathlib/`) for
-closely related results — do not rely on web searches or AI knowledge of Mathlib, which
-may be out of date. Open one GitHub issue per candidate to track the research and verdict.
+#### Setup
 
-For each candidate, determine:
-1. Is the result already in Mathlib, possibly under a different name or with different type
-   class assumptions? (Check related files carefully — not just exact name matches.)
-2. Is there a close relative in Mathlib such that the candidate is just a straightforward
-   corollary or type-class variant?
-3. Is the proof approach genuinely new, or does it reconstruct something Mathlib already
-   proves elsewhere?
+Create `gh label create proof-polish --color c5def5` (ignore error if exists). Create one issue per chapter (or per item for complex proofs):
+- Title: `Polish proofs in Chapter N` or `Polish <ItemID>`
+- Label: `proof-polish`
 
-Based on the research, assign one of three verdicts:
+#### Agent workflow
 
-- **Reject — insufficient interest:** The result is too narrow, the proof quality doesn't
-  meet Mathlib standards, or it's not a good fit.
-- **Reject — already in Mathlib:** Found an equivalent result. Create a GitHub issue to
-  refactor the proof to use the Mathlib declaration directly, and update the item's
-  `progress/items.json` status to `mathlib_covered`.
-- **Include in UPSTREAMING.md:** Genuinely new to Mathlib, correct, and at appropriate
-  generality and quality.
+Each agent assigned to a proof-polish issue:
 
-#### Phase 3: Write UPSTREAMING.md
+1. Reviews each sorry-free proof in its scope
+2. Applies cleanup:
+   - Combine redundant steps (`rw [a]; rw [b]` → `rw [a, b]`)
+   - Replace verbose tactic sequences with more powerful single tactics where appropriate
+   - Remove unnecessary intermediate steps (test by deleting and checking if the proof still works)
+   - Ensure `simp` calls use minimal lemma sets where practical
+   - Follow Mathlib naming conventions and style
+3. Verifies the polished proof still compiles
+4. Submits a PR with auto-merge enabled
 
-Write `UPSTREAMING.md` at the repository root with the following structure:
+#### Status transitions
 
-```markdown
-# Upstreaming Candidates
+After polishing: items move from `dependency_trimmed` → `proof_polished` in `progress/items.json`.
 
-These are suggestions only — no actual upstreaming has occurred.
+**Output:** Polished `.lean` files. Updated `progress/items.json`.
 
-## Included
+**Verify:** All previously sorry-free items have status `proof_polished`. `lake build` succeeds.
 
-### <Item ID> — `theorem_name`
+### Stage 3.6: Upstreaming Analysis
 
-**File:** `path/to/Item.lean`
+Identify formalized results that may be worth contributing to Mathlib. The output is a non-binding `UPSTREAMING.md` report — no actual upstreaming happens here.
 
-**Statement:** (the Lean statement)
+#### Phase 1: Lightweight triage
 
-**Why it's new:** What was searched, what was found, why this is absent.
+Scan all proof-polished items. Reject immediately if the proof is a one-liner delegating to a named Mathlib theorem, or trivial glue between two or three existing Mathlib facts. Keep as candidate if the proof is substantive and the result appears absent from Mathlib's API.
 
-**Suggested home:** Which Mathlib file/module it belongs in.
+#### Phase 2: Deep Mathlib research
 
-## Excluded
+For each candidate, search the **local Mathlib source** (`.lake/packages/mathlib/`) for closely related results — do not rely on web searches or AI knowledge of Mathlib, which may be out of date. Check for equivalent results under different names, close relatives that make the candidate a straightforward corollary, and proof approaches that reconstruct something Mathlib already proves elsewhere. Open one GitHub issue per candidate to track the research.
 
-### <Item ID> — reason
+Assign one of three verdicts:
 
-One-line reason (already in Mathlib as `FooBar.baz`, too narrow, etc.).
-```
+- **Reject — already in Mathlib:** Create a GitHub issue to refactor the proof to use the Mathlib declaration directly, and set `upstreaming_status` to `mathlib_covered`.
+- **Reject — insufficient interest:** Too narrow, not at Mathlib quality/generality, or not a good fit.
+- **Include in UPSTREAMING.md:** Genuinely new to Mathlib, correct, and at appropriate generality.
 
 #### Output
 
-- `UPSTREAMING.md` at the repository root
-- GitHub issues for any items whose proofs should be refactored to use Mathlib directly
-- `progress/items.json` updated with `"upstreaming_status"` field:
-  - `"candidate"` — included in UPSTREAMING.md
-  - `"mathlib_covered"` — already in Mathlib, refactor issue opened
-  - `"rejected"` — not a candidate
+Write `UPSTREAMING.md` at the repository root. For each included candidate: the item ID, Lean declaration name, file path, Lean statement, why it's new (what was searched, what was found), and suggested Mathlib module. For excluded items: one-line reason each.
+
+Update `progress/items.json` with `"upstreaming_status"`: `"candidate"`, `"mathlib_covered"`, or `"rejected"`.
 
-**Verify:** `UPSTREAMING.md` exists. Every proof-polished item has an `upstreaming_status`
-in `progress/items.json`.
+**Verify:** `UPSTREAMING.md` exists. Every proof-polished item has an `upstreaming_status` in `progress/items.json`.
 
 ---
 
@@ -552,7 +613,11 @@ Commits made during a turn should mention the corresponding progress file in the
 ### Item-level progress: `progress/items.json`
 
 Item statuses flow through:
-`identified` → `extracted` → `statement_formalized` → `proof_formalized` → `sorry_free` → `dependency_trimmed` → `proof_polished`
+`identified` → `extracted` → `scaffolded` → `definition_verified` → `proof_formalized` → `sorry_free` → `dependency_trimmed` → `proof_polished`
+
+Special statuses (set during review):
+- `needs_definition` — the item has a definition-level sorry that must be resolved before downstream theorems are meaningful
+- `attention_needed` — requires specialized agent attention (e.g., wrong statement, repeated failures)
 
 ```json
 {
```

🤖 Prepared with Claude Code